### PR TITLE
Setup

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,3 +19,6 @@ galaxy_info:
     - ssl:tls
     - system
 
+dependencies:
+  - inofix.acme-setup
+


### PR DESCRIPTION
Add acme-setup as dependency - there is still a dependency to either
acme-request or the acme-cron-proxy.